### PR TITLE
Update group pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
           - "golang.org/x/*"
       otel:
         patterns:
+          - "go.opentelemetry.io/otel"
           - "go.opentelemetry.io/otel/*"
           - "go.opentelemetry.io/contrib/*"
     labels:


### PR DESCRIPTION
Ensure that the root OTel package is in the group. This should result in fewer Dependabot PRs.