### PR TITLE
Enable pausing and resuming

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -435,6 +435,10 @@ func (p *Processor) Pause() {
 	p.paused.Store(true)
 }
 
+func (p *Processor) Paused() bool {
+	return p.paused.Load()
+}
+
 func (p *Processor) Resume() {
 	p.paused.Store(false)
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -312,7 +312,7 @@ func TestProcessor_no_handler(t *testing.T) {
 	assert.NotNil(fooUpdatedEvent.ProcessedAt)
 }
 
-func TestProcessor_Pause_Resume(t *testing.T) {
+func TestProcessor_Pause_Paused_Resume(t *testing.T) {
 	assert := assert.New(t)
 
 	duration := 100 * time.Millisecond
@@ -340,6 +340,8 @@ func TestProcessor_Pause_Resume(t *testing.T) {
 	assert.NoError(err)
 
 	p.Pause()
+
+	assert.True(p.Paused())
 
 	go func() {
 		err := p.Start(context.Background(), duration, limit)
@@ -402,6 +404,8 @@ func TestProcessor_Pause_Resume(t *testing.T) {
 	}).Once()
 
 	p.Resume()
+
+	assert.False(p.Paused())
 
 	wg.Wait()
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -311,3 +311,108 @@ func TestProcessor_no_handler(t *testing.T) {
 
 	assert.NotNil(fooUpdatedEvent.ProcessedAt)
 }
+
+func TestProcessor_Pause_Resume(t *testing.T) {
+	assert := assert.New(t)
+
+	duration := 100 * time.Millisecond
+	limit := 5
+
+	eventRepo := NewMockRepository(t)
+
+	fooSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
+		return nil
+	})
+
+	barSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
+		return nil
+	})
+
+	barFailureHandler := NewHandler("failure", "", func(ctx context.Context, e *Event) error {
+		return errors.New("handler error")
+	})
+
+	eventMap := ConfigMap{}
+	eventMap.AddHandlers("fooUpdated", fooSuccessHandler)
+	eventMap.AddHandlers("barUpdated", barSuccessHandler, barFailureHandler)
+
+	p, err := NewProcessor(eventRepo, eventMap, nil, "", 2)
+	assert.NoError(err)
+
+	p.Pause()
+
+	go func() {
+		err := p.Start(context.Background(), duration, limit)
+		assert.NoError(err)
+	}()
+
+	// Sleep for a couple of ticks to ensure that the processing has been paused.
+	time.Sleep(5 * duration)
+
+	entityID := uuid.New().String()
+
+	fooUpdatedEvent, err := NewApplicationEvent("fooUpdated", map[string]any{"key": "val"})
+	assert.NoError(err)
+	fooUpdatedEvent.EntityID = &entityID
+
+	barUpdatedEvent, err := NewApplicationEvent("barUpdated", map[string]any{"key": "val"})
+	assert.NoError(err)
+	barUpdatedEvent.EntityID = &entityID
+
+	events := []*Event{
+		fooUpdatedEvent,
+		barUpdatedEvent,
+	}
+
+	eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
+		err := f(eventRepo)
+		assert.NoError(err)
+
+		return nil
+	})
+
+	eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
+		err := f(eventRepo)
+		assert.NoError(err)
+
+		return nil
+	})
+
+	eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return(events, nil).Once()
+	eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return([]*Event{}, nil)
+
+	eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedEvent.ID, true).Return(fooUpdatedEvent, nil).Once()
+	eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, barUpdatedEvent.ID, true).Return(barUpdatedEvent, nil).Once()
+
+	var wg sync.WaitGroup
+	wg.Add(len(events))
+
+	eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
+		return e.ID == fooUpdatedEvent.ID
+	})).RunAndReturn(func(ctx context.Context, e *Event) error {
+		wg.Done()
+		return nil
+	}).Once()
+
+	eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
+		return e.ID == barUpdatedEvent.ID
+	})).RunAndReturn(func(ctx context.Context, e *Event) error {
+		wg.Done()
+		return nil
+	}).Once()
+
+	p.Resume()
+
+	wg.Wait()
+
+	err = p.Shutdown(context.Background())
+	assert.NoError(err)
+
+	assert.NotNil(fooUpdatedEvent.ProcessedAt)
+
+	assert.Nil(barUpdatedEvent.ProcessedAt)
+	assert.NotNil(barUpdatedEvent.HandlerResults["success"].ProcessedAt)
+
+	assert.Nil(barUpdatedEvent.HandlerResults["failure"].ProcessedAt)
+	assert.Error(barUpdatedEvent.HandlerResults["failure"].LastError)
+}


### PR DESCRIPTION
This PR enables callers to the Processor to pause or resume processing. It also allows them to check if processing is paused. This may be useful for maintenance or troubleshooting.