### PR TITLE
Track running processors

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -558,7 +558,7 @@ func (p *Processor) handleProcessorEvent(ctx context.Context, event processorEve
 	previousStatus := p.status
 	p.status = nextStatus
 
-	// Keep track of the number of running event processors and their state (e.g., paused).
+	// Keep track of the number of running event processors and their state (i.e., paused or not paused).
 	if previousStatus.running() {
 		p.statusUpDownCounter.Add(
 			ctx,

--- a/processor.go
+++ b/processor.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -38,6 +37,41 @@ var _ BackoffFunc = DefaultBackoffFunc
 
 type BeforeProcessHook func(context.Context, *Event) (context.Context, *Event, error)
 
+type ProcessorStatus string
+
+const (
+	ProcessorStatusNotStarted       ProcessorStatus = "notStarted"
+	ProcessorStatusNotStartedPaused ProcessorStatus = "notStartedPaused"
+	ProcessorStatusRunning          ProcessorStatus = "running"
+	ProcessorStatusRunningPaused    ProcessorStatus = "runningPaused"
+	ProcessorStatusShutDown         ProcessorStatus = "shutDown"
+)
+
+func (ps ProcessorStatus) String() string {
+	return string(ps)
+}
+
+func (ps ProcessorStatus) notStarted() bool {
+	return ps == ProcessorStatusNotStarted || ps == ProcessorStatusNotStartedPaused
+}
+
+func (ps ProcessorStatus) paused() bool {
+	return ps == ProcessorStatusNotStartedPaused || ps == ProcessorStatusRunningPaused
+}
+
+func (ps ProcessorStatus) running() bool {
+	return ps == ProcessorStatusRunning || ps == ProcessorStatusRunningPaused
+}
+
+type processorEvent string
+
+const (
+	processorEventPaused   processorEvent = "paused"
+	processorEventResumed  processorEvent = "resumed"
+	processorEventShutDown processorEvent = "shutDown"
+	processorEventStarted  processorEvent = "started"
+)
+
 type Processor struct {
 	beforeProcessHook          BeforeProcessHook
 	configMap                  ConfigMap
@@ -47,9 +81,11 @@ type Processor struct {
 	meter                      metric.Meter
 	meterCallbackRegistrations []metric.Registration
 	numProcessorWorkers        int
-	paused                     atomic.Bool
 	repo                       Repository
 	shutdown                   chan bool
+	status                     ProcessorStatus
+	statusRWMutex              sync.RWMutex
+	statusUpDownCounter        metric.Int64UpDownCounter
 	successCounter             metric.Int64Counter
 	telemetryPrefix            string
 	timeHistogram              metric.Float64Histogram
@@ -76,6 +112,7 @@ func NewProcessor(
 		meter:               otel.GetMeterProvider().Meter("github.com/authorhealth/events"),
 		numProcessorWorkers: numProcessorWorkers,
 		repo:                repo,
+		status:              ProcessorStatusNotStarted,
 		telemetryPrefix:     telemetryPrefix,
 		shutdown:            make(chan bool, 1),
 		tracer:              otel.GetTracerProvider().Tracer("github.com/authorhealth/events"),
@@ -131,10 +168,22 @@ func NewProcessor(
 		return nil, fmt.Errorf("constructing dead event count gauge: %w", err)
 	}
 
+	p.statusUpDownCounter, err = p.meter.Int64UpDownCounter(
+		p.applyTelemetryPrefix("events.processor.status"),
+		metric.WithDescription("Operational status for the processor: 1 (true) or 0 (false) for each of the possible states"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("constructing processor status up/down counter: %w", err)
+	}
+
 	return p, nil
 }
 
 func (p *Processor) Start(ctx context.Context, interval time.Duration, limit int) error {
+	if !p.Status().notStarted() {
+		return errors.New("processor is already started")
+	}
+
 	defer func() {
 		p.done <- true
 	}()
@@ -144,12 +193,14 @@ func (p *Processor) Start(ctx context.Context, interval time.Duration, limit int
 		return fmt.Errorf("registering meter callbacks: %w", err)
 	}
 
+	p.handleProcessorEvent(ctx, processorEventStarted)
+
 	ticker := time.NewTicker(interval)
 
 	for {
 		select {
 		case <-ticker.C:
-			if !p.paused.Load() {
+			if !p.Paused() {
 				p.processEvents(ctx, limit)
 			}
 
@@ -339,7 +390,13 @@ func (p *Processor) processEvent(ctx context.Context, event *Event) {
 }
 
 func (p *Processor) Shutdown(ctx context.Context) error {
+	if !p.Status().running() {
+		return errors.New("processor is not running")
+	}
+
 	p.shutdown <- true
+
+	p.handleProcessorEvent(ctx, processorEventShutDown)
 
 	for {
 		select {
@@ -431,14 +488,104 @@ func (p *Processor) unregisterMeterCallbacks() error {
 	return nil
 }
 
-func (p *Processor) Pause() {
-	p.paused.Store(true)
+func (p *Processor) Pause(ctx context.Context) {
+	p.handleProcessorEvent(ctx, processorEventPaused)
 }
 
 func (p *Processor) Paused() bool {
-	return p.paused.Load()
+	return p.Status().paused()
 }
 
-func (p *Processor) Resume() {
-	p.paused.Store(false)
+func (p *Processor) Resume(ctx context.Context) {
+	p.handleProcessorEvent(ctx, processorEventResumed)
+}
+
+func (p *Processor) Status() ProcessorStatus {
+	p.statusRWMutex.RLock()
+	defer p.statusRWMutex.RUnlock()
+
+	return p.status
+}
+
+func (p *Processor) handleProcessorEvent(ctx context.Context, event processorEvent) {
+	p.statusRWMutex.Lock()
+	defer p.statusRWMutex.Unlock()
+
+	nextStatus := p.status
+
+	switch p.status {
+	case ProcessorStatusNotStarted:
+		switch event {
+		case processorEventStarted:
+			nextStatus = ProcessorStatusRunning
+
+		case processorEventPaused:
+			nextStatus = ProcessorStatusNotStartedPaused
+		}
+
+	case ProcessorStatusNotStartedPaused:
+		switch event {
+		case processorEventStarted:
+			nextStatus = ProcessorStatusRunningPaused
+
+		case processorEventResumed:
+			nextStatus = ProcessorStatusNotStarted
+		}
+
+	case ProcessorStatusRunning:
+		switch event {
+		case processorEventPaused:
+			nextStatus = ProcessorStatusRunningPaused
+
+		case processorEventShutDown:
+			nextStatus = ProcessorStatusShutDown
+		}
+
+	case ProcessorStatusRunningPaused:
+		switch event {
+		case processorEventResumed:
+			nextStatus = ProcessorStatusRunning
+
+		case processorEventShutDown:
+			nextStatus = ProcessorStatusShutDown
+		}
+	}
+
+	if nextStatus == p.status {
+		return
+	}
+
+	previousStatus := p.status
+	p.status = nextStatus
+
+	// Keep track of the number of running event processors and their state (e.g., paused).
+	if previousStatus.running() {
+		p.statusUpDownCounter.Add(
+			ctx,
+			-1,
+			metric.WithAttributeSet(
+				attribute.NewSet(
+					attribute.String(
+						p.applyTelemetryPrefix("events.processor.state"),
+						previousStatus.String(),
+					),
+				),
+			),
+		)
+	}
+
+	if p.status.running() {
+		p.statusUpDownCounter.Add(
+			ctx,
+			1,
+			metric.WithAttributeSet(
+				attribute.NewSet(
+					attribute.String(
+						p.applyTelemetryPrefix("events.processor.state"),
+						p.status.String(),
+					),
+				),
+			),
+		)
+	}
 }

--- a/processor.go
+++ b/processor.go
@@ -382,7 +382,7 @@ func (p *Processor) processEvent(ctx context.Context, event *Event) {
 
 func (p *Processor) Shutdown(ctx context.Context) error {
 	if !p.Status().operational() {
-		return errors.New("processor is not running")
+		return errors.New("processor is not operational")
 	}
 
 	p.shutdown <- true
@@ -477,6 +477,10 @@ func (p *Processor) unregisterMeterCallbacks() error {
 	p.meterCallbackRegistrations = nil
 
 	return nil
+}
+
+func (p *Processor) Operational() bool {
+	return p.Status().operational()
 }
 
 func (p *Processor) Pause(ctx context.Context) {

--- a/processor_test.go
+++ b/processor_test.go
@@ -312,111 +312,268 @@ func TestProcessor_no_handler(t *testing.T) {
 	assert.NotNil(fooUpdatedEvent.ProcessedAt)
 }
 
-func TestProcessor_Pause_Paused_Resume(t *testing.T) {
+func TestProcessor_Pause_Paused_Resume_Status(t *testing.T) {
+	testCases := map[string]struct {
+		pauseAfterProcessing bool
+	}{
+		"don't pause after processing": {},
+		"pause after processing": {
+			pauseAfterProcessing: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Arrange - Processor not started
+			interval := 100 * time.Millisecond
+			limit := 5
+
+			eventRepo := NewMockRepository(t)
+
+			fooSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
+				return nil
+			})
+
+			barSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
+				return nil
+			})
+
+			barFailureHandler := NewHandler("failure", "", func(ctx context.Context, e *Event) error {
+				return errors.New("handler error")
+			})
+
+			eventMap := ConfigMap{}
+			eventMap.AddHandlers("fooUpdated", fooSuccessHandler)
+			eventMap.AddHandlers("barUpdated", barSuccessHandler, barFailureHandler)
+
+			// Act/Assert - Processor not started
+			processor, err := NewProcessor(eventRepo, eventMap, nil, "", 2)
+
+			assert.NoError(err)
+			assert.False(processor.Paused())
+			assert.Equal(ProcessorStatusNotStarted, processor.Status())
+
+			// Act/Assert - Processor not started - paused
+			processor.Pause(context.Background())
+
+			assert.True(processor.Paused())
+			assert.Equal(ProcessorStatusNotStartedPaused, processor.Status())
+
+			// Act/Assert - Processor not started - paused (idempotent)
+			processor.Pause(context.Background())
+
+			assert.True(processor.Paused())
+			assert.Equal(ProcessorStatusNotStartedPaused, processor.Status())
+
+			// Act/Assert - Processor not started - resumed
+			processor.Resume(context.Background())
+
+			assert.False(processor.Paused())
+			assert.Equal(ProcessorStatusNotStarted, processor.Status())
+
+			// Act/Assert - Processor not started - paused
+			processor.Pause(context.Background())
+
+			assert.True(processor.Paused())
+			assert.Equal(ProcessorStatusNotStartedPaused, processor.Status())
+
+			// Act/Assert - Processor running - paused
+			go func() {
+				err := processor.Start(context.Background(), interval, limit)
+				assert.NoError(err)
+			}()
+
+			time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the processor has started.
+
+			assert.Equal(ProcessorStatusRunningPaused, processor.Status())
+
+			// Arrange - Processor running - resumed
+			entityID := uuid.New().String()
+
+			fooUpdatedEvent, err := NewApplicationEvent("fooUpdated", map[string]any{"key": "val"})
+			assert.NoError(err)
+			fooUpdatedEvent.EntityID = &entityID
+
+			barUpdatedEvent, err := NewApplicationEvent("barUpdated", map[string]any{"key": "val"})
+			assert.NoError(err)
+			barUpdatedEvent.EntityID = &entityID
+
+			events := []*Event{
+				fooUpdatedEvent,
+				barUpdatedEvent,
+			}
+
+			eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
+				err := f(eventRepo)
+				assert.NoError(err)
+
+				return nil
+			})
+
+			eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
+				err := f(eventRepo)
+				assert.NoError(err)
+
+				return nil
+			})
+
+			eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return(events, nil).Once()
+			eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return([]*Event{}, nil)
+
+			eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedEvent.ID, true).Return(fooUpdatedEvent, nil).Once()
+			eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, barUpdatedEvent.ID, true).Return(barUpdatedEvent, nil).Once()
+
+			var wg sync.WaitGroup
+			wg.Add(len(events))
+
+			eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
+				return e.ID == fooUpdatedEvent.ID
+			})).RunAndReturn(func(ctx context.Context, e *Event) error {
+				wg.Done()
+				return nil
+			}).Once()
+
+			eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
+				return e.ID == barUpdatedEvent.ID
+			})).RunAndReturn(func(ctx context.Context, e *Event) error {
+				wg.Done()
+				return nil
+			}).Once()
+
+			// Act/Assert - Processor running - resumed
+			processor.Resume(context.Background())
+
+			assert.False(processor.Paused())
+			assert.Equal(ProcessorStatusRunning, processor.Status())
+
+			wg.Wait()
+
+			assert.NotNil(fooUpdatedEvent.ProcessedAt)
+
+			assert.Nil(barUpdatedEvent.ProcessedAt)
+			assert.NotNil(barUpdatedEvent.HandlerResults["success"].ProcessedAt)
+
+			assert.Nil(barUpdatedEvent.HandlerResults["failure"].ProcessedAt)
+			assert.Error(barUpdatedEvent.HandlerResults["failure"].LastError)
+
+			if testCase.pauseAfterProcessing {
+				// Act/Assert - Processor running - paused
+				processor.Pause(context.Background())
+
+				assert.True(processor.Paused())
+				assert.Equal(ProcessorStatusRunningPaused, processor.Status())
+			}
+
+			err = processor.Shutdown(context.Background())
+			assert.NoError(err)
+
+			assert.Equal(ProcessorStatusShutDown, processor.Status())
+		})
+	}
+}
+
+func TestProcessor_Start_already_started(t *testing.T) {
+	testCases := map[string]struct {
+		paused bool
+	}{
+		"not paused": {},
+		"paused": {
+			paused: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Arrange
+			interval := 100 * time.Millisecond
+			limit := 5
+
+			eventRepo := NewMockRepository(t)
+			eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return(nil, nil).Maybe()
+
+			processor, err := NewProcessor(eventRepo, nil, nil, "", 2)
+			assert.NoError(err)
+
+			if testCase.paused {
+				processor.Pause(context.Background())
+			}
+
+			go func() {
+				err := processor.Start(context.Background(), interval, limit)
+				assert.NoError(err)
+			}()
+
+			time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the processor has started.
+
+			// Act
+			err = processor.Start(context.Background(), interval, limit)
+
+			// Assert
+			assert.EqualError(err, "processor is already started")
+		})
+	}
+}
+
+func TestProcessor_Shutdown_not_running(t *testing.T) {
+	testCases := map[string]struct {
+		paused bool
+	}{
+		"not paused": {},
+		"paused": {
+			paused: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Arrange
+			eventRepo := NewMockRepository(t)
+
+			processor, err := NewProcessor(eventRepo, nil, nil, "", 2)
+			assert.NoError(err)
+
+			if testCase.paused {
+				processor.Pause(context.Background())
+			}
+
+			// Act
+			err = processor.Shutdown(context.Background())
+
+			// Assert
+			assert.EqualError(err, "processor is not running")
+		})
+	}
+}
+
+func TestProcessor_Shutdown_already_shut_down(t *testing.T) {
 	assert := assert.New(t)
 
-	duration := 100 * time.Millisecond
+	// Arrange
+	interval := 100 * time.Millisecond
 	limit := 5
 
 	eventRepo := NewMockRepository(t)
+	eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return(nil, nil).Maybe()
 
-	fooSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
-		return nil
-	})
-
-	barSuccessHandler := NewHandler("success", "", func(ctx context.Context, e *Event) error {
-		return nil
-	})
-
-	barFailureHandler := NewHandler("failure", "", func(ctx context.Context, e *Event) error {
-		return errors.New("handler error")
-	})
-
-	eventMap := ConfigMap{}
-	eventMap.AddHandlers("fooUpdated", fooSuccessHandler)
-	eventMap.AddHandlers("barUpdated", barSuccessHandler, barFailureHandler)
-
-	p, err := NewProcessor(eventRepo, eventMap, nil, "", 2)
+	processor, err := NewProcessor(eventRepo, nil, nil, "", 2)
 	assert.NoError(err)
 
-	p.Pause()
-
-	assert.True(p.Paused())
-
 	go func() {
-		err := p.Start(context.Background(), duration, limit)
+		err := processor.Start(context.Background(), interval, limit)
 		assert.NoError(err)
 	}()
 
-	// Sleep for a couple of ticks to ensure that the processing has been paused.
-	time.Sleep(5 * duration)
+	time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the processor has started.
 
-	entityID := uuid.New().String()
-
-	fooUpdatedEvent, err := NewApplicationEvent("fooUpdated", map[string]any{"key": "val"})
-	assert.NoError(err)
-	fooUpdatedEvent.EntityID = &entityID
-
-	barUpdatedEvent, err := NewApplicationEvent("barUpdated", map[string]any{"key": "val"})
-	assert.NoError(err)
-	barUpdatedEvent.EntityID = &entityID
-
-	events := []*Event{
-		fooUpdatedEvent,
-		barUpdatedEvent,
-	}
-
-	eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
-		err := f(eventRepo)
-		assert.NoError(err)
-
-		return nil
-	})
-
-	eventRepo.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Repository) error")).RunAndReturn(func(ctx context.Context, f func(Repository) error) error {
-		err := f(eventRepo)
-		assert.NoError(err)
-
-		return nil
-	})
-
-	eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return(events, nil).Once()
-	eventRepo.EXPECT().FindUnprocessed(ctxMatcher, limit).Return([]*Event{}, nil)
-
-	eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedEvent.ID, true).Return(fooUpdatedEvent, nil).Once()
-	eventRepo.EXPECT().FindByIDForUpdate(ctxMatcher, barUpdatedEvent.ID, true).Return(barUpdatedEvent, nil).Once()
-
-	var wg sync.WaitGroup
-	wg.Add(len(events))
-
-	eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
-		return e.ID == fooUpdatedEvent.ID
-	})).RunAndReturn(func(ctx context.Context, e *Event) error {
-		wg.Done()
-		return nil
-	}).Once()
-
-	eventRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(e *Event) bool {
-		return e.ID == barUpdatedEvent.ID
-	})).RunAndReturn(func(ctx context.Context, e *Event) error {
-		wg.Done()
-		return nil
-	}).Once()
-
-	p.Resume()
-
-	assert.False(p.Paused())
-
-	wg.Wait()
-
-	err = p.Shutdown(context.Background())
+	err = processor.Shutdown(context.Background())
 	assert.NoError(err)
 
-	assert.NotNil(fooUpdatedEvent.ProcessedAt)
+	// Act
+	err = processor.Shutdown(context.Background())
 
-	assert.Nil(barUpdatedEvent.ProcessedAt)
-	assert.NotNil(barUpdatedEvent.HandlerResults["success"].ProcessedAt)
-
-	assert.Nil(barUpdatedEvent.HandlerResults["failure"].ProcessedAt)
-	assert.Error(barUpdatedEvent.HandlerResults["failure"].LastError)
+	// Assert
+	assert.EqualError(err, "processor is not running")
 }


### PR DESCRIPTION
This PR adds a new up/down counter metric for tracking the number of running event processors and their state (i.e., paused or not paused). This metric can be used, for example, to trigger an alert when there are no running processors or all the running processors are paused.