### PR TITLE
Add limit and offset to FindDead

### DIFF
--- a/demo/store.go
+++ b/demo/store.go
@@ -407,7 +407,7 @@ func (r *HandlerRequestRepository) FindByIDForUpdate(ctx context.Context, id str
 	return row.handlerRequest, nil
 }
 
-func (r *HandlerRequestRepository) FindDead(ctx context.Context) ([]*events.HandlerRequest, error) {
+func (r *HandlerRequestRepository) FindDead(ctx context.Context, limit int, offset int) ([]*events.HandlerRequest, error) {
 	r.db.handlerRequestTableMutex.RLock()
 	defer r.db.handlerRequestTableMutex.RUnlock()
 
@@ -430,7 +430,13 @@ func (r *HandlerRequestRepository) FindDead(ctx context.Context) ([]*events.Hand
 		deadHandlerRequests = append(deadHandlerRequests, row.handlerRequest)
 	}
 
-	return deadHandlerRequests, nil
+	if offset >= len(deadHandlerRequests) {
+		return nil, nil
+	}
+
+	end := min(offset+limit, len(deadHandlerRequests))
+
+	return deadHandlerRequests[offset:end], nil
 }
 
 func (r *HandlerRequestRepository) FindOldestUnexecuted(ctx context.Context) (*events.HandlerRequest, error) {

--- a/store.go
+++ b/store.go
@@ -33,7 +33,7 @@ type HandlerRequestRepository interface {
 	Find(ctx context.Context) iter.Seq2[*HandlerRequest, error]
 	FindByID(ctx context.Context, id string) (*HandlerRequest, error)
 	FindByIDForUpdate(ctx context.Context, id string, skipLocked bool) (*HandlerRequest, error)
-	FindDead(ctx context.Context) ([]*HandlerRequest, error)
+	FindDead(ctx context.Context, limit int, offset int) ([]*HandlerRequest, error)
 	FindOldestUnexecuted(ctx context.Context) (*HandlerRequest, error)
 	FindUnexecuted(ctx context.Context, limit int) ([]*HandlerRequest, error)
 	Update(ctx context.Context, handlerRequest *HandlerRequest) error


### PR DESCRIPTION
This PR adds limit and offset parameters to FindDead to allow paginating through the dead handler requests.