### PR TITLE
Implement executor queues

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,10 +6,11 @@ const (
 )
 
 type HandlerConfig struct {
-	BackoffFunction BackoffFunc // The backoff function to call when execution fails.
-	Handler         *Handler    // The handler for the event.
-	MaxErrors       int         // The maximum error limit for the handler.
-	Priority        int         // The priority rank of the handler.
+	BackoffFunction BackoffFunc       // The backoff function to call when execution fails.
+	Handler         *Handler          // The handler for the event.
+	MaxErrors       int               // The maximum error limit for the handler.
+	QueueName       ExecutorQueueName // The name of the executor queue where the handler request will be executed.
+	Priority        int               // The priority rank of the handler.
 }
 
 type HandlerConfigOption func(handlerConfig *HandlerConfig)
@@ -32,6 +33,12 @@ func WithPriority(priority int) HandlerConfigOption {
 	}
 }
 
+func WithQueue(queueName ExecutorQueueName) HandlerConfigOption {
+	return func(handlerConfig *HandlerConfig) {
+		handlerConfig.QueueName = queueName
+	}
+}
+
 type HandlerConfigMap map[HandlerName]*HandlerConfig
 
 type HandlerConfigMapOption func(handlerConfigMap HandlerConfigMap)
@@ -44,6 +51,7 @@ func WithHandler(handler *Handler, options ...HandlerConfigOption) HandlerConfig
 		if handlerConfig == nil {
 			handlerConfig = &HandlerConfig{
 				MaxErrors: defaultMaxErrors,
+				QueueName: DefaultExecutorQueueName,
 				Priority:  defaultPriority,
 			}
 			handlerConfigMap[handlerName] = handlerConfig

--- a/demo/store.go
+++ b/demo/store.go
@@ -309,6 +309,36 @@ func (r *HandlerRequestRepository) CountDead(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+func (r *HandlerRequestRepository) CountDeadByQueue(ctx context.Context, queueName events.ExecutorQueueName) (int, error) {
+	r.db.handlerRequestTableMutex.RLock()
+	defer r.db.handlerRequestTableMutex.RUnlock()
+
+	slog.DebugContext(ctx, "counting dead handler requests")
+
+	var count int
+	for _, row := range r.db.handlerRequestTable {
+		if row.handlerRequest.QueueName != queueName {
+			continue
+		}
+
+		if row.handlerRequest.CompletedAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.CanceledAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.Errors < row.handlerRequest.MaxErrors {
+			continue
+		}
+
+		count++
+	}
+
+	return count, nil
+}
+
 func (r *HandlerRequestRepository) CountUnexecuted(ctx context.Context) (int, error) {
 	r.db.handlerRequestTableMutex.RLock()
 	defer r.db.handlerRequestTableMutex.RUnlock()
@@ -317,6 +347,40 @@ func (r *HandlerRequestRepository) CountUnexecuted(ctx context.Context) (int, er
 
 	var count int
 	for _, row := range r.db.handlerRequestTable {
+		if row.handlerRequest.CompletedAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.CanceledAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.Errors >= row.handlerRequest.MaxErrors {
+			continue
+		}
+
+		if row.handlerRequest.BackoffUntil != nil && row.handlerRequest.BackoffUntil.After(time.Now()) {
+			continue
+		}
+
+		count++
+	}
+
+	return count, nil
+}
+
+func (r *HandlerRequestRepository) CountUnexecutedByQueue(ctx context.Context, queueName events.ExecutorQueueName) (int, error) {
+	r.db.handlerRequestTableMutex.RLock()
+	defer r.db.handlerRequestTableMutex.RUnlock()
+
+	slog.DebugContext(ctx, "counting unexecuted handler requests")
+
+	var count int
+	for _, row := range r.db.handlerRequestTable {
+		if row.handlerRequest.QueueName != queueName {
+			continue
+		}
+
 		if row.handlerRequest.CompletedAt != nil {
 			continue
 		}
@@ -475,6 +539,46 @@ func (r *HandlerRequestRepository) FindOldestUnexecuted(ctx context.Context) (*e
 	return oldestUnexecutedHandlerRequest, nil
 }
 
+func (r *HandlerRequestRepository) FindOldestUnexecutedByQueue(ctx context.Context, queueName events.ExecutorQueueName) (*events.HandlerRequest, error) {
+	r.db.handlerRequestTableMutex.RLock()
+	defer r.db.handlerRequestTableMutex.RUnlock()
+
+	slog.DebugContext(ctx, "finding oldest unexecuted handler request")
+
+	var oldestUnexecutedHandlerRequest *events.HandlerRequest
+	for _, row := range r.db.handlerRequestTable {
+		if row.handlerRequest.QueueName != queueName {
+			continue
+		}
+
+		if row.handlerRequest.CompletedAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.CanceledAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.Errors >= row.handlerRequest.MaxErrors {
+			continue
+		}
+
+		if row.handlerRequest.BackoffUntil != nil && row.handlerRequest.BackoffUntil.After(time.Now()) {
+			continue
+		}
+
+		if oldestUnexecutedHandlerRequest == nil || row.handlerRequest.EventTimestamp.Before(oldestUnexecutedHandlerRequest.EventTimestamp) {
+			oldestUnexecutedHandlerRequest = row.handlerRequest
+		}
+	}
+
+	if oldestUnexecutedHandlerRequest == nil {
+		return nil, events.ErrNotFound
+	}
+
+	return oldestUnexecutedHandlerRequest, nil
+}
+
 func (r *HandlerRequestRepository) FindUnexecuted(ctx context.Context, limit int) ([]*events.HandlerRequest, error) {
 	r.db.handlerRequestTableMutex.RLock()
 	defer r.db.handlerRequestTableMutex.RUnlock()
@@ -497,6 +601,57 @@ func (r *HandlerRequestRepository) FindUnexecuted(ctx context.Context, limit int
 	for _, row := range sortedItems {
 		if len(unexecutedHandlerRequests) >= limit {
 			break
+		}
+
+		if row.handlerRequest.CompletedAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.CanceledAt != nil {
+			continue
+		}
+
+		if row.handlerRequest.Errors >= row.handlerRequest.MaxErrors {
+			continue
+		}
+
+		if row.handlerRequest.BackoffUntil != nil && row.handlerRequest.BackoffUntil.After(time.Now()) {
+			continue
+		}
+
+		unexecutedHandlerRequests = append(unexecutedHandlerRequests, row.handlerRequest)
+	}
+
+	return unexecutedHandlerRequests, nil
+}
+
+// FindUnexecutedByQueue implements events.HandlerRequestRepository.
+func (r *HandlerRequestRepository) FindUnexecutedByQueue(ctx context.Context, queueName events.ExecutorQueueName, limit int) ([]*events.HandlerRequest, error) {
+	r.db.handlerRequestTableMutex.RLock()
+	defer r.db.handlerRequestTableMutex.RUnlock()
+
+	slog.DebugContext(ctx, "finding unexecuted handler requests", "limit", limit)
+
+	sortedItems := slices.SortedStableFunc(maps.Values(r.db.handlerRequestTable), func(a *HandlerRequestTableRow, b *HandlerRequestTableRow) int {
+		if a.handlerRequest.Priority < b.handlerRequest.Priority {
+			return -1
+		}
+
+		if a.handlerRequest.Priority > b.handlerRequest.Priority {
+			return 1
+		}
+
+		return a.handlerRequest.EventTimestamp.Compare(b.handlerRequest.EventTimestamp)
+	})
+
+	var unexecutedHandlerRequests []*events.HandlerRequest
+	for _, row := range sortedItems {
+		if len(unexecutedHandlerRequests) >= limit {
+			break
+		}
+
+		if row.handlerRequest.QueueName != queueName {
+			continue
 		}
 
 		if row.handlerRequest.CompletedAt != nil {

--- a/executor_test.go
+++ b/executor_test.go
@@ -11,7 +11,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 )
 
-func TestExecutor_executeRequests(t *testing.T) {
+func TestDefaultExecutor_executeRequests(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -19,13 +19,13 @@ func TestExecutor_executeRequests(t *testing.T) {
 	fooUpdatedEvent, err := NewApplicationEvent(fooUpdatedEventName, map[string]any{"key": "val"})
 	assert.NoError(err)
 
-	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority)
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, DefaultExecutorQueueName)
 	assert.NoError(err)
 
 	barUpdatedEvent, err := NewDomainEvent(barUpdatedEventName, uuid.New().String(), "bar", map[string]any{"key": "val"})
 	assert.NoError(err)
 
-	barUpdatedHandlerRequest, err := NewHandlerRequest(barUpdatedEvent, barUpdatedHandlerName, defaultMaxErrors, defaultPriority)
+	barUpdatedHandlerRequest, err := NewHandlerRequest(barUpdatedEvent, barUpdatedHandlerName, defaultMaxErrors, defaultPriority, DefaultExecutorQueueName)
 	assert.NoError(err)
 
 	requests := []*HandlerRequest{
@@ -72,13 +72,13 @@ func TestExecutor_executeRequests(t *testing.T) {
 		WithEvent(barUpdatedEventName, WithHandler(barUpdatedHandler)),
 	)
 
-	e, err := NewExecutor(store, eventMap, nil, "", 2)
+	e, err := NewDefaultExecutor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	e.executeRequests(context.Background(), limit)
+	e.executeRequests(context.Background())
 }
 
-func TestExecutor_executeRequests_not_found(t *testing.T) {
+func TestDefaultExecutor_executeRequests_not_found(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -91,7 +91,7 @@ func TestExecutor_executeRequests_not_found(t *testing.T) {
 		ProcessedAt: nil,
 	}
 
-	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority)
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, DefaultExecutorQueueName)
 	assert.NoError(err)
 
 	requests := []*HandlerRequest{
@@ -123,13 +123,13 @@ func TestExecutor_executeRequests_not_found(t *testing.T) {
 		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler)),
 	)
 
-	e, err := NewExecutor(store, eventMap, nil, "", 2)
+	e, err := NewDefaultExecutor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	e.executeRequests(context.Background(), limit)
+	e.executeRequests(context.Background())
 }
 
-func TestExecutor_executeRequests_already_executed(t *testing.T) {
+func TestDefaultExecutor_executeRequests_already_executed(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -142,7 +142,7 @@ func TestExecutor_executeRequests_already_executed(t *testing.T) {
 		Timestamp: now,
 	}
 
-	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority)
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, DefaultExecutorQueueName)
 	assert.NoError(err)
 
 	fooUpdatedHandlerRequest.CompletedAt = &now
@@ -176,8 +176,182 @@ func TestExecutor_executeRequests_already_executed(t *testing.T) {
 		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler)),
 	)
 
-	e, err := NewExecutor(store, eventMap, nil, "", 2)
+	e, err := NewDefaultExecutor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	e.executeRequests(context.Background(), limit)
+	e.executeRequests(context.Background())
+}
+
+func TestQueueExecutor_executeRequests(t *testing.T) {
+	assert := assert.New(t)
+
+	queueName := ExecutorQueueName("myQueue")
+	limit := 5
+
+	fooUpdatedEvent, err := NewApplicationEvent(fooUpdatedEventName, map[string]any{"key": "val"})
+	assert.NoError(err)
+
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, queueName)
+	assert.NoError(err)
+
+	barUpdatedEvent, err := NewDomainEvent(barUpdatedEventName, uuid.New().String(), "bar", map[string]any{"key": "val"})
+	assert.NoError(err)
+
+	barUpdatedHandlerRequest, err := NewHandlerRequest(barUpdatedEvent, barUpdatedHandlerName, defaultMaxErrors, defaultPriority, queueName)
+	assert.NoError(err)
+
+	requests := []*HandlerRequest{
+		fooUpdatedHandlerRequest,
+		barUpdatedHandlerRequest,
+	}
+
+	txHandlerRequestRepo := NewMockHandlerRequestRepository(t)
+	txHandlerRequestRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedHandlerRequest.ID, true).Return(fooUpdatedHandlerRequest, nil).Once()
+	txHandlerRequestRepo.EXPECT().FindByIDForUpdate(ctxMatcher, barUpdatedHandlerRequest.ID, true).Return(barUpdatedHandlerRequest, nil).Once()
+	txHandlerRequestRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(r *HandlerRequest) bool {
+		return r.ID == fooUpdatedHandlerRequest.ID &&
+			assert.NotNil(r.CompletedAt)
+	})).Return(nil).Once()
+	txHandlerRequestRepo.EXPECT().Update(ctxMatcher, mock.MatchedBy(func(r *HandlerRequest) bool {
+		return r.ID == barUpdatedHandlerRequest.ID &&
+			assert.Nil(r.CompletedAt) &&
+			assert.Error(r.LastError)
+	})).Return(nil).Once()
+
+	txStore := NewMockStorer(t)
+	txStore.EXPECT().HandlerRequests().Return(txHandlerRequestRepo)
+
+	handlerRequestRepo := NewMockHandlerRequestRepository(t)
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return(requests, nil).Once()
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return([]*HandlerRequest{}, nil).Maybe()
+
+	store := NewMockStorer(t)
+	store.EXPECT().HandlerRequests().Return(handlerRequestRepo)
+	store.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Storer) error")).RunAndReturn(func(ctx context.Context, f func(Storer) error) error {
+		return f(txStore)
+	})
+
+	fooUpdatedHandler := NewHandler(fooUpdatedHandlerName, "", func(ctx context.Context, r *HandlerRequest) error {
+		return nil
+	})
+
+	barUpdatedHandler := NewHandler(barUpdatedHandlerName, "", func(ctx context.Context, r *HandlerRequest) error {
+		return errors.New("handler error")
+	})
+
+	eventMap := NewConfigMap(
+		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler, WithQueue(queueName))),
+		WithEvent(barUpdatedEventName, WithHandler(barUpdatedHandler, WithQueue(queueName))),
+	)
+
+	e, err := NewQueueExecutor(store, eventMap, nil, "", 2, limit, queueName)
+	assert.NoError(err)
+
+	e.executeRequests(context.Background())
+}
+
+func TestQueueExecutor_executeRequests_not_found(t *testing.T) {
+	assert := assert.New(t)
+
+	queueName := ExecutorQueueName("myQueue")
+	limit := 5
+
+	fooUpdatedEvent := &Event{
+		ID:          uuid.New().String(),
+		Name:        fooUpdatedEventName,
+		Data:        map[string]any{"key": "val"},
+		Timestamp:   time.Now(),
+		ProcessedAt: nil,
+	}
+
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, queueName)
+	assert.NoError(err)
+
+	requests := []*HandlerRequest{
+		fooUpdatedHandlerRequest,
+	}
+
+	txHandlerRequestRepo := NewMockHandlerRequestRepository(t)
+	txHandlerRequestRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedHandlerRequest.ID, true).Return(nil, ErrNotFound)
+
+	txStore := NewMockStorer(t)
+	txStore.EXPECT().HandlerRequests().Return(txHandlerRequestRepo)
+
+	handlerRequestRepo := NewMockHandlerRequestRepository(t)
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return(requests, nil).Once()
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return([]*HandlerRequest{}, nil).Maybe()
+
+	store := NewMockStorer(t)
+	store.EXPECT().HandlerRequests().Return(handlerRequestRepo)
+	store.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Storer) error")).RunAndReturn(func(ctx context.Context, f func(Storer) error) error {
+		return f(txStore)
+	})
+
+	fooUpdatedHandler := NewHandler(fooUpdatedHandlerName, "", func(ctx context.Context, r *HandlerRequest) error {
+		assert.Fail("should not have been called")
+		return nil
+	})
+
+	eventMap := NewConfigMap(
+		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler, WithQueue(queueName))),
+	)
+
+	e, err := NewQueueExecutor(store, eventMap, nil, "", 2, limit, queueName)
+	assert.NoError(err)
+
+	e.executeRequests(context.Background())
+}
+
+func TestQueueExecutor_executeRequests_already_executed(t *testing.T) {
+	assert := assert.New(t)
+
+	queueName := ExecutorQueueName("myQueue")
+	limit := 5
+
+	now := time.Now()
+	fooUpdatedEvent := &Event{
+		ID:        uuid.New().String(),
+		Name:      fooUpdatedEventName,
+		Data:      map[string]any{"key": "val"},
+		Timestamp: now,
+	}
+
+	fooUpdatedHandlerRequest, err := NewHandlerRequest(fooUpdatedEvent, fooUpdatedHandlerName, defaultMaxErrors, defaultPriority, queueName)
+	assert.NoError(err)
+
+	fooUpdatedHandlerRequest.CompletedAt = &now
+
+	requests := []*HandlerRequest{
+		fooUpdatedHandlerRequest,
+	}
+
+	txHandlerRequestRepo := NewMockHandlerRequestRepository(t)
+	txHandlerRequestRepo.EXPECT().FindByIDForUpdate(ctxMatcher, fooUpdatedHandlerRequest.ID, true).Return(fooUpdatedHandlerRequest, nil)
+
+	txStore := NewMockStorer(t)
+	txStore.EXPECT().HandlerRequests().Return(txHandlerRequestRepo)
+
+	handlerRequestRepo := NewMockHandlerRequestRepository(t)
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return(requests, nil).Once()
+	handlerRequestRepo.EXPECT().FindUnexecutedByQueue(ctxMatcher, queueName, limit).Return([]*HandlerRequest{}, nil).Maybe()
+
+	store := NewMockStorer(t)
+	store.EXPECT().HandlerRequests().Return(handlerRequestRepo)
+	store.EXPECT().Transaction(ctxMatcher, mock.AnythingOfType("func(events.Storer) error")).RunAndReturn(func(ctx context.Context, f func(Storer) error) error {
+		return f(txStore)
+	})
+
+	fooUpdatedHandler := NewHandler(fooUpdatedHandlerName, "", func(ctx context.Context, r *HandlerRequest) error {
+		assert.Fail("should not have been called")
+		return nil
+	})
+
+	eventMap := NewConfigMap(
+		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler, WithQueue(queueName))),
+	)
+
+	e, err := NewQueueExecutor(store, eventMap, nil, "", 2, limit, queueName)
+	assert.NoError(err)
+
+	e.executeRequests(context.Background())
 }

--- a/handler_request.go
+++ b/handler_request.go
@@ -9,26 +9,33 @@ import (
 )
 
 type HandlerRequest struct {
-	ID              string         // The request ID.
-	BackoffUntil    *time.Time     // The time at which execution should be tried again.
-	CanceledAt      *time.Time     // When the request was marked as canceled.
-	CompletedAt     *time.Time     // When the event handler execution successfully completed.
-	CorrelationID   string         // CorrelationID is a read-only field that is set by the storage layer.
-	Errors          int            // Errors indicates the number of execution attempts that resulted in errors.
-	EventData       map[string]any // The key/value pairs associated with the event.
-	EventEntityID   string         // The event entity ID.
-	EventEntityName string         // The event entity name.
-	EventID         string         // The event ID.
-	EventName       EventName      // Name represents the event name.
-	EventTimestamp  time.Time      // When the event occurred.
-	HandlerName     HandlerName    // The name of the event handler to execute.
-	LastAttemptAt   *time.Time     // LastAttemptAt indicates when execution was last attempted.
-	LastError       error          // LastError contains the error that occurred when execution was last attempted.
-	MaxErrors       int            // The maximum error limit for the request.
-	Priority        int            // The priority rank of the request.
+	ID              string            // The request ID.
+	BackoffUntil    *time.Time        // The time at which execution should be tried again.
+	CanceledAt      *time.Time        // When the request was marked as canceled.
+	CompletedAt     *time.Time        // When the event handler execution successfully completed.
+	CorrelationID   string            // CorrelationID is a read-only field that is set by the storage layer.
+	Errors          int               // Errors indicates the number of execution attempts that resulted in errors.
+	EventData       map[string]any    // The key/value pairs associated with the event.
+	EventEntityID   string            // The event entity ID.
+	EventEntityName string            // The event entity name.
+	EventID         string            // The event ID.
+	EventName       EventName         // Name represents the event name.
+	EventTimestamp  time.Time         // When the event occurred.
+	HandlerName     HandlerName       // The name of the event handler to execute.
+	LastAttemptAt   *time.Time        // LastAttemptAt indicates when execution was last attempted.
+	LastError       error             // LastError contains the error that occurred when execution was last attempted.
+	MaxErrors       int               // The maximum error limit for the request.
+	Priority        int               // The priority rank of the request.
+	QueueName       ExecutorQueueName // The name of the executor queue where the request will be executed.
 }
 
-func NewHandlerRequest(event *Event, handlerName HandlerName, maxErrors int, priority int) (*HandlerRequest, error) {
+func NewHandlerRequest(
+	event *Event,
+	handlerName HandlerName,
+	maxErrors int,
+	priority int,
+	queueName ExecutorQueueName,
+) (*HandlerRequest, error) {
 	if len(handlerName) == 0 {
 		return nil, errors.New("handlerName is empty")
 	}
@@ -45,6 +52,7 @@ func NewHandlerRequest(event *Event, handlerName HandlerName, maxErrors int, pri
 		HandlerName:     handlerName,
 		MaxErrors:       maxErrors,
 		Priority:        priority,
+		QueueName:       queueName,
 	}, nil
 }
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -10,7 +10,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 )
 
-func TestProcessor_processEvents(t *testing.T) {
+func TestDefaultProcessor_processEvents(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -75,13 +75,13 @@ func TestProcessor_processEvents(t *testing.T) {
 		WithEvent(barUpdatedEventName, WithHandler(barUpdatedHandler)),
 	)
 
-	p, err := NewProcessor(store, eventMap, nil, "", 2)
+	p, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	p.processEvents(context.Background(), limit)
+	p.processEvents(context.Background())
 }
 
-func TestProcessor_processEvents_not_found(t *testing.T) {
+func TestDefaultProcessor_processEvents_not_found(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -123,13 +123,13 @@ func TestProcessor_processEvents_not_found(t *testing.T) {
 		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler)),
 	)
 
-	p, err := NewProcessor(store, eventMap, nil, "", 2)
+	p, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	p.processEvents(context.Background(), limit)
+	p.processEvents(context.Background())
 }
 
-func TestProcessor_processEvents_already_processed(t *testing.T) {
+func TestDefaultProcessor_processEvents_already_processed(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -172,13 +172,13 @@ func TestProcessor_processEvents_already_processed(t *testing.T) {
 		WithEvent(fooUpdatedEventName, WithHandler(fooUpdatedHandler)),
 	)
 
-	p, err := NewProcessor(store, eventMap, nil, "", 2)
+	p, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	p.processEvents(context.Background(), limit)
+	p.processEvents(context.Background())
 }
 
-func TestProcessor_processEvents_no_handler(t *testing.T) {
+func TestDefaultProcessor_processEvents_no_handler(t *testing.T) {
 	assert := assert.New(t)
 
 	limit := 5
@@ -215,8 +215,8 @@ func TestProcessor_processEvents_no_handler(t *testing.T) {
 
 	eventMap := ConfigMap{}
 
-	p, err := NewProcessor(store, eventMap, nil, "", 2)
+	p, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	p.processEvents(context.Background(), limit)
+	p.processEvents(context.Background())
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -38,58 +38,60 @@ const (
 	schedulerEventStarted  schedulerEvent = "started"
 )
 
-// Scheduler cooperatively schedules work for the Processor and the Executor.
-//
-// The Scheduler starts by calling the Processor to process events and create handler execution requests.
-// Then, the Scheduler calls the Executor to execute handler execution requests.
-// This quick succession helps minimize the gap between processing and execution.
+// Scheduler provides a standard interface for scheduling work for the Processor and the Executor(s).
 //
 // The Scheduler also provides a Shutdown method to gracefully stop scheduling work.
-type Scheduler struct {
-	done                chan bool
-	executor            *Executor
-	meter               metric.Meter
-	processor           *Processor
-	shutdown            chan bool
-	status              SchedulerStatus
-	statusRWMutex       sync.RWMutex
-	statusUpDownCounter metric.Int64UpDownCounter
-	telemetryPrefix     string
+type Scheduler interface {
+	Start(ctx context.Context) error
+	Shutdown(ctx context.Context) error
+	Operational() bool
+	Pause(ctx context.Context)
+	Paused() bool
+	Resume(ctx context.Context)
+	Status() SchedulerStatus
 }
 
-func NewScheduler(
-	processor *Processor,
-	executor *Executor,
+// CooperativeScheduler cooperatively schedules work for the Processor and the Executor.
+//
+// The CooperativeScheduler starts by calling the Processor to process events and create handler execution requests.
+// Then, the CooperativeScheduler calls the Executor to execute handler execution requests.
+// This quick succession helps minimize the gap between processing and execution.
+type CooperativeScheduler struct {
+	*schedulerStateMachine
+
+	done      chan bool
+	executor  Executor
+	interval  time.Duration
+	processor Processor
+	shutdown  chan bool
+}
+
+var _ Scheduler = (*CooperativeScheduler)(nil)
+
+func NewCooperativeScheduler(
+	processor Processor,
+	executor Executor,
 	telemetryPrefix string,
-) (*Scheduler, error) {
-	s := &Scheduler{
-		done:            make(chan bool, 1),
-		meter:           otel.GetMeterProvider().Meter("github.com/authorhealth/events/v2"),
-		executor:        executor,
-		processor:       processor,
-		shutdown:        make(chan bool, 1),
-		status:          SchedulerStatusNotStarted,
-		telemetryPrefix: telemetryPrefix,
+	interval time.Duration,
+) (*CooperativeScheduler, error) {
+	ssm, err := newSchedulerStateMachine(telemetryPrefix)
+	if err != nil {
+		return nil, err
 	}
 
-	var err error
-	s.statusUpDownCounter, err = s.meter.Int64UpDownCounter(
-		s.applyTelemetryPrefix("events.scheduler.status"),
-		metric.WithDescription("Operational status for the scheduler: 1 (true) or 0 (false) for each of the possible states"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("constructing scheduler status up/down counter: %w", err)
+	s := &CooperativeScheduler{
+		done:                  make(chan bool, 1),
+		executor:              executor,
+		interval:              interval,
+		processor:             processor,
+		schedulerStateMachine: ssm,
+		shutdown:              make(chan bool, 1),
 	}
 
 	return s, nil
 }
 
-func (s *Scheduler) Start(
-	ctx context.Context,
-	interval time.Duration,
-	processorLimit int,
-	executorLimit int,
-) error {
+func (s *CooperativeScheduler) Start(ctx context.Context) error {
 	if s.Status() != SchedulerStatusNotStarted {
 		return errors.New("scheduler is already started")
 	}
@@ -110,14 +112,14 @@ func (s *Scheduler) Start(
 
 	s.handleProcessorEvent(ctx, schedulerEventStarted)
 
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(s.interval)
 
 	for {
 		select {
 		case <-ticker.C:
 			if !s.Paused() {
-				s.processor.processEvents(ctx, processorLimit)
-				s.executor.executeRequests(ctx, executorLimit)
+				s.processor.processEvents(ctx)
+				s.executor.executeRequests(ctx)
 			}
 
 		case <-s.shutdown:
@@ -126,14 +128,14 @@ func (s *Scheduler) Start(
 	}
 }
 
-func (s *Scheduler) Shutdown(ctx context.Context) error {
+func (s *CooperativeScheduler) Shutdown(ctx context.Context) error {
 	if !s.Status().operational() {
 		return errors.New("scheduler is not operational")
 	}
 
 	s.shutdown <- true
-	s.processor.shutdown <- true
-	s.executor.shutdown <- true
+	s.processor.shutdown()
+	s.executor.shutdown()
 
 	s.handleProcessorEvent(ctx, schedulerEventShutdown)
 
@@ -158,36 +160,207 @@ func (s *Scheduler) Shutdown(ctx context.Context) error {
 	}
 }
 
-func (s *Scheduler) Operational() bool {
-	return s.Status().operational()
+// ConcurrentScheduler concurrently schedules work for the Processor and the Executors.
+type ConcurrentScheduler struct {
+	*schedulerStateMachine
+
+	done      chan bool
+	executors []Executor
+	interval  time.Duration
+	processor Processor
+	shutdown  chan struct{}
 }
 
-func (s *Scheduler) Pause(ctx context.Context) {
-	s.handleProcessorEvent(ctx, schedulerEventPaused)
+var _ Scheduler = (*ConcurrentScheduler)(nil)
+
+func NewConcurrentScheduler(
+	processor Processor,
+	executors []Executor,
+	telemetryPrefix string,
+	interval time.Duration,
+) (*ConcurrentScheduler, error) {
+	ssm, err := newSchedulerStateMachine(telemetryPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &ConcurrentScheduler{
+		done:                  make(chan bool, 1),
+		executors:             executors,
+		interval:              interval,
+		processor:             processor,
+		schedulerStateMachine: ssm,
+		shutdown:              make(chan struct{}),
+	}
+
+	return s, nil
 }
 
-func (s *Scheduler) Paused() bool {
-	return s.Status() == SchedulerStatusPaused
+func (s *ConcurrentScheduler) Start(ctx context.Context) error {
+	if s.Status() != SchedulerStatusNotStarted {
+		return errors.New("scheduler is already started")
+	}
+
+	defer func() {
+		s.done <- true
+	}()
+
+	err := s.processor.registerMeterCallbacks()
+	if err != nil {
+		return fmt.Errorf("registering processor meter callbacks: %w", err)
+	}
+
+	for _, executor := range s.executors {
+		err = executor.registerMeterCallbacks()
+		if err != nil {
+			return fmt.Errorf("registering executor meter callbacks: %w", err)
+		}
+	}
+
+	s.handleProcessorEvent(ctx, schedulerEventStarted)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(s.interval)
+
+		for {
+			select {
+			case <-ticker.C:
+				if !s.Paused() {
+					s.processor.processEvents(ctx)
+				}
+
+			case <-s.shutdown:
+				return
+			}
+		}
+	}()
+
+	for _, executor := range s.executors {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ticker := time.NewTicker(s.interval)
+
+			for {
+				select {
+				case <-ticker.C:
+					if !s.Paused() {
+						executor.executeRequests(ctx)
+					}
+
+				case <-s.shutdown:
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return nil
 }
 
-func (s *Scheduler) Resume(ctx context.Context) {
-	s.handleProcessorEvent(ctx, schedulerEventResumed)
+func (s *ConcurrentScheduler) Shutdown(ctx context.Context) error {
+	if !s.Status().operational() {
+		return errors.New("scheduler is not operational")
+	}
+
+	close(s.shutdown)
+	s.processor.shutdown()
+	for _, executor := range s.executors {
+		executor.shutdown()
+	}
+
+	s.handleProcessorEvent(ctx, schedulerEventShutdown)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-s.done:
+			err := s.processor.unregisterMeterCallbacks()
+			if err != nil {
+				return fmt.Errorf("unregistering processor meter callbacks: %w", err)
+			}
+
+			for _, executor := range s.executors {
+				err = executor.unregisterMeterCallbacks()
+				if err != nil {
+					return fmt.Errorf("unregistering executor meter callbacks: %w", err)
+				}
+			}
+
+			return nil
+		}
+	}
 }
 
-func (s *Scheduler) Status() SchedulerStatus {
-	s.statusRWMutex.RLock()
-	defer s.statusRWMutex.RUnlock()
-
-	return s.status
+type schedulerStateMachine struct {
+	meter               metric.Meter
+	status              SchedulerStatus
+	statusRWMutex       sync.RWMutex
+	statusUpDownCounter metric.Int64UpDownCounter
+	telemetryPrefix     string
 }
 
-func (s *Scheduler) handleProcessorEvent(ctx context.Context, event schedulerEvent) {
-	s.statusRWMutex.Lock()
-	defer s.statusRWMutex.Unlock()
+func newSchedulerStateMachine(
+	telemetryPrefix string,
+) (*schedulerStateMachine, error) {
+	ssm := &schedulerStateMachine{
+		meter:           otel.GetMeterProvider().Meter("github.com/authorhealth/events/v2"),
+		status:          SchedulerStatusNotStarted,
+		telemetryPrefix: telemetryPrefix,
+	}
 
-	nextStatus := s.status
+	var err error
+	ssm.statusUpDownCounter, err = ssm.meter.Int64UpDownCounter(
+		ssm.applyTelemetryPrefix("events.scheduler.status"),
+		metric.WithDescription("Operational status for the scheduler: 1 (true) or 0 (false) for each of the possible states"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("constructing scheduler status up/down counter: %w", err)
+	}
 
-	switch s.status {
+	return ssm, nil
+}
+
+func (ssm *schedulerStateMachine) Operational() bool {
+	return ssm.Status().operational()
+}
+
+func (ssm *schedulerStateMachine) Pause(ctx context.Context) {
+	ssm.handleProcessorEvent(ctx, schedulerEventPaused)
+}
+
+func (ssm *schedulerStateMachine) Paused() bool {
+	return ssm.Status() == SchedulerStatusPaused
+}
+
+func (ssm *schedulerStateMachine) Resume(ctx context.Context) {
+	ssm.handleProcessorEvent(ctx, schedulerEventResumed)
+}
+
+func (ssm *schedulerStateMachine) Status() SchedulerStatus {
+	ssm.statusRWMutex.RLock()
+	defer ssm.statusRWMutex.RUnlock()
+
+	return ssm.status
+}
+
+func (ssm *schedulerStateMachine) handleProcessorEvent(ctx context.Context, event schedulerEvent) {
+	ssm.statusRWMutex.Lock()
+	defer ssm.statusRWMutex.Unlock()
+
+	nextStatus := ssm.status
+
+	switch ssm.status {
 	case SchedulerStatusNotStarted:
 		switch event {
 		case schedulerEventStarted:
@@ -213,22 +386,22 @@ func (s *Scheduler) handleProcessorEvent(ctx context.Context, event schedulerEve
 		}
 	}
 
-	if nextStatus == s.status {
+	if nextStatus == ssm.status {
 		return
 	}
 
-	previousStatus := s.status
-	s.status = nextStatus
+	previousStatus := ssm.status
+	ssm.status = nextStatus
 
 	// Keep track of the number of operational schedulers and their state (i.e., running or paused).
 	if previousStatus.operational() {
-		s.statusUpDownCounter.Add(
+		ssm.statusUpDownCounter.Add(
 			ctx,
 			-1,
 			metric.WithAttributeSet(
 				attribute.NewSet(
 					attribute.String(
-						s.applyTelemetryPrefix("events.scheduler.state"),
+						ssm.applyTelemetryPrefix("events.scheduler.state"),
 						previousStatus.String(),
 					),
 				),
@@ -236,15 +409,15 @@ func (s *Scheduler) handleProcessorEvent(ctx context.Context, event schedulerEve
 		)
 	}
 
-	if s.status.operational() {
-		s.statusUpDownCounter.Add(
+	if ssm.status.operational() {
+		ssm.statusUpDownCounter.Add(
 			ctx,
 			1,
 			metric.WithAttributeSet(
 				attribute.NewSet(
 					attribute.String(
-						s.applyTelemetryPrefix("events.scheduler.state"),
-						s.status.String(),
+						ssm.applyTelemetryPrefix("events.scheduler.state"),
+						ssm.status.String(),
 					),
 				),
 			),
@@ -252,9 +425,9 @@ func (s *Scheduler) handleProcessorEvent(ctx context.Context, event schedulerEve
 	}
 }
 
-func (s *Scheduler) applyTelemetryPrefix(k string) string {
-	if len(s.telemetryPrefix) > 0 {
-		return fmt.Sprintf("%s.%s", s.telemetryPrefix, k)
+func (ssm *schedulerStateMachine) applyTelemetryPrefix(k string) string {
+	if len(ssm.telemetryPrefix) > 0 {
+		return fmt.Sprintf("%s.%s", ssm.telemetryPrefix, k)
 	}
 
 	return k

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 )
 
-func TestScheduler(t *testing.T) {
+func TestCooperativeScheduler(t *testing.T) {
 	assert := assert.New(t)
 
 	interval := 100 * time.Millisecond
@@ -137,17 +138,17 @@ func TestScheduler(t *testing.T) {
 		WithEvent(barUpdatedEventName, WithHandler(barUpdatedHandler)),
 	)
 
-	processor, err := NewProcessor(store, eventMap, nil, "", 2)
+	processor, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	executor, err := NewExecutor(store, eventMap, nil, "", 2)
+	executor, err := NewDefaultExecutor(store, eventMap, nil, "", 2, limit)
 	assert.NoError(err)
 
-	scheduler, err := NewScheduler(processor, executor, "")
+	scheduler, err := NewCooperativeScheduler(processor, executor, "", interval)
 	assert.NoError(err)
 
 	go func() {
-		err := scheduler.Start(context.Background(), interval, limit, limit)
+		err := scheduler.Start(context.Background())
 		assert.NoError(err)
 	}()
 
@@ -157,7 +158,7 @@ func TestScheduler(t *testing.T) {
 	assert.NoError(err)
 }
 
-func TestScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
+func TestCooperativeScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
 	testCases := map[string]struct {
 		pauseAfterProcessing bool
 	}{
@@ -215,14 +216,14 @@ func TestScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
 			store.EXPECT().Events().Return(eventRepo)
 			store.EXPECT().HandlerRequests().Return(handlerRequestRepo)
 
-			processor, err := NewProcessor(store, eventMap, nil, "", 2)
+			processor, err := NewDefaultProcessor(store, eventMap, nil, "", 2, limit)
 			assert.NoError(err)
 
-			executor, err := NewExecutor(store, eventMap, nil, "", 2)
+			executor, err := NewDefaultExecutor(store, eventMap, nil, "", 2, limit)
 			assert.NoError(err)
 
 			// Act/Assert - Scheduler not started
-			scheduler, err := NewScheduler(processor, executor, "")
+			scheduler, err := NewCooperativeScheduler(processor, executor, "", interval)
 
 			assert.NoError(err)
 			assert.False(scheduler.Operational())
@@ -231,7 +232,7 @@ func TestScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
 
 			// Act/Assert - Scheduler running - no events or handler requests available
 			go func() {
-				err := scheduler.Start(context.Background(), interval, limit, limit)
+				err := scheduler.Start(context.Background())
 				assert.NoError(err)
 			}()
 
@@ -383,7 +384,7 @@ func TestScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
 	}
 }
 
-func TestScheduler_Start_already_started(t *testing.T) {
+func TestCooperativeScheduler_Start_already_started(t *testing.T) {
 	testCases := map[string]struct {
 		paused bool
 	}{
@@ -410,13 +411,13 @@ func TestScheduler_Start_already_started(t *testing.T) {
 			store.EXPECT().Events().Return(eventRepo).Maybe()
 			store.EXPECT().HandlerRequests().Return(handlerRequestRepo).Maybe()
 
-			processor, err := NewProcessor(store, nil, nil, "", 2)
+			processor, err := NewDefaultProcessor(store, nil, nil, "", 2, limit)
 			assert.NoError(err)
 
-			executor, err := NewExecutor(store, nil, nil, "", 2)
+			executor, err := NewDefaultExecutor(store, nil, nil, "", 2, limit)
 			assert.NoError(err)
 
-			scheduler, err := NewScheduler(processor, executor, "")
+			scheduler, err := NewCooperativeScheduler(processor, executor, "", interval)
 			assert.NoError(err)
 
 			if testCase.paused {
@@ -424,14 +425,14 @@ func TestScheduler_Start_already_started(t *testing.T) {
 			}
 
 			go func() {
-				err := scheduler.Start(context.Background(), interval, limit, limit)
+				err := scheduler.Start(context.Background())
 				assert.NoError(err)
 			}()
 
 			time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the scheduler has started.
 
 			// Act
-			err = scheduler.Start(context.Background(), interval, limit, limit)
+			err = scheduler.Start(context.Background())
 
 			// Assert
 			assert.EqualError(err, "scheduler is already started")
@@ -439,7 +440,7 @@ func TestScheduler_Start_already_started(t *testing.T) {
 	}
 }
 
-func TestScheduler_Shutdown_not_running(t *testing.T) {
+func TestCooperativeScheduler_Shutdown_not_running(t *testing.T) {
 	testCases := map[string]struct {
 		paused bool
 	}{
@@ -455,13 +456,13 @@ func TestScheduler_Shutdown_not_running(t *testing.T) {
 			// Arrange
 			store := NewMockStorer(t)
 
-			processor, err := NewProcessor(store, nil, nil, "", 2)
+			processor, err := NewDefaultProcessor(store, nil, nil, "", 2, 5)
 			assert.NoError(err)
 
-			executor, err := NewExecutor(store, nil, nil, "", 2)
+			executor, err := NewDefaultExecutor(store, nil, nil, "", 2, 5)
 			assert.NoError(err)
 
-			scheduler, err := NewScheduler(processor, executor, "")
+			scheduler, err := NewCooperativeScheduler(processor, executor, "", 100*time.Millisecond)
 			assert.NoError(err)
 
 			if testCase.paused {
@@ -477,7 +478,7 @@ func TestScheduler_Shutdown_not_running(t *testing.T) {
 	}
 }
 
-func TestScheduler_Shutdown_already_shut_down(t *testing.T) {
+func TestCooperativeScheduler_Shutdown_already_shut_down(t *testing.T) {
 	assert := assert.New(t)
 
 	// Arrange
@@ -494,17 +495,265 @@ func TestScheduler_Shutdown_already_shut_down(t *testing.T) {
 	store.EXPECT().Events().Return(eventRepo).Maybe()
 	store.EXPECT().HandlerRequests().Return(handlerRequestRepo).Maybe()
 
-	processor, err := NewProcessor(store, nil, nil, "", 2)
+	processor, err := NewDefaultProcessor(store, nil, nil, "", 2, limit)
 	assert.NoError(err)
 
-	executor, err := NewExecutor(store, nil, nil, "", 2)
+	executor, err := NewDefaultExecutor(store, nil, nil, "", 2, limit)
 	assert.NoError(err)
 
-	scheduler, err := NewScheduler(processor, executor, "")
+	scheduler, err := NewCooperativeScheduler(processor, executor, "", interval)
 	assert.NoError(err)
 
 	go func() {
-		err := scheduler.Start(context.Background(), interval, limit, limit)
+		err := scheduler.Start(context.Background())
+		assert.NoError(err)
+	}()
+
+	time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the scheduler has started.
+
+	err = scheduler.Shutdown(context.Background())
+	assert.NoError(err)
+
+	// Act
+	err = scheduler.Shutdown(context.Background())
+
+	// Assert
+	assert.EqualError(err, "scheduler is not operational")
+}
+
+func TestConcurrentScheduler(t *testing.T) {
+	assert := assert.New(t)
+
+	interval := 100 * time.Millisecond
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	var processorCalled atomic.Bool
+	processor := NewMockProcessor(t)
+	processor.EXPECT().processEvents(context.Background()).RunAndReturn(func(_ context.Context) {
+		if processorCalled.CompareAndSwap(false, true) {
+			wg.Done()
+		}
+	})
+	processor.EXPECT().registerMeterCallbacks().Return(nil)
+	processor.EXPECT().shutdown().Return()
+	processor.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	var executor1Called atomic.Bool
+	executor1 := NewMockExecutor(t)
+	executor1.EXPECT().executeRequests(context.Background()).RunAndReturn(func(_ context.Context) {
+		if executor1Called.CompareAndSwap(false, true) {
+			wg.Done()
+		}
+	})
+	executor1.EXPECT().registerMeterCallbacks().Return(nil)
+	executor1.EXPECT().shutdown().Return()
+	executor1.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	var executor2Called atomic.Bool
+	executor2 := NewMockExecutor(t)
+	executor2.EXPECT().executeRequests(context.Background()).RunAndReturn(func(_ context.Context) {
+		if executor2Called.CompareAndSwap(false, true) {
+			wg.Done()
+		}
+	})
+	executor2.EXPECT().registerMeterCallbacks().Return(nil)
+	executor2.EXPECT().shutdown().Return()
+	executor2.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	scheduler, err := NewConcurrentScheduler(
+		processor,
+		[]Executor{executor1, executor2},
+		"",
+		interval,
+	)
+	assert.NoError(err)
+
+	go func() {
+		err := scheduler.Start(context.Background())
+		assert.NoError(err)
+	}()
+
+	wg.Wait()
+
+	err = scheduler.Shutdown(context.Background())
+	assert.NoError(err)
+}
+
+func TestConcurrentScheduler_Operational_Pause_Paused_Resume_Status(t *testing.T) {
+	assert := assert.New(t)
+
+	// Arrange - Scheduler not started
+	interval := 100 * time.Millisecond
+
+	processor := NewMockProcessor(t)
+	processor.EXPECT().processEvents(context.Background()).Return()
+	processor.EXPECT().registerMeterCallbacks().Return(nil)
+	processor.EXPECT().shutdown().Return()
+	processor.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	executor1 := NewMockExecutor(t)
+	executor1.EXPECT().executeRequests(context.Background()).Return()
+	executor1.EXPECT().registerMeterCallbacks().Return(nil)
+	executor1.EXPECT().shutdown().Return()
+	executor1.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	executor2 := NewMockExecutor(t)
+	executor2.EXPECT().executeRequests(context.Background()).Return()
+	executor2.EXPECT().registerMeterCallbacks().Return(nil)
+	executor2.EXPECT().shutdown().Return()
+	executor2.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	// Act/Assert - Scheduler not started
+	scheduler, err := NewConcurrentScheduler(
+		processor,
+		[]Executor{executor1, executor2},
+		"",
+		interval,
+	)
+
+	assert.NoError(err)
+	assert.False(scheduler.Operational())
+	assert.False(scheduler.Paused())
+	assert.Equal(SchedulerStatusNotStarted, scheduler.Status())
+
+	// Act/Assert - Scheduler running
+	go func() {
+		err := scheduler.Start(context.Background())
+		assert.NoError(err)
+	}()
+
+	time.Sleep(3 * interval) // Sleep for a couple of ticks to ensure the scheduler has had time to run.
+
+	assert.False(scheduler.Paused())
+	assert.True(scheduler.Operational())
+	assert.Equal(SchedulerStatusRunning, scheduler.Status())
+
+	// Act/Assert - Scheduler paused
+	scheduler.Pause(context.Background())
+	assert.True(scheduler.Operational())
+	assert.True(scheduler.Paused())
+	assert.Equal(SchedulerStatusPaused, scheduler.Status())
+
+	// Act/Assert - Scheduler resumed
+	scheduler.Resume(context.Background())
+	assert.True(scheduler.Operational())
+	assert.False(scheduler.Paused())
+	assert.Equal(SchedulerStatusRunning, scheduler.Status())
+
+	// Act/Assert - Scheduler shut down
+	err = scheduler.Shutdown(context.Background())
+	assert.NoError(err)
+
+	assert.False(scheduler.Operational())
+	assert.False(scheduler.Paused())
+	assert.Equal(SchedulerStatusShutdown, scheduler.Status())
+}
+
+func TestConcurrentScheduler_Start_already_started(t *testing.T) {
+	testCases := map[string]struct {
+		paused bool
+	}{
+		"not paused": {},
+		"paused": {
+			paused: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Arrange
+			interval := 100 * time.Millisecond
+
+			processor := NewMockProcessor(t)
+			processor.EXPECT().processEvents(context.Background()).Return().Maybe()
+			processor.EXPECT().registerMeterCallbacks().Return(nil).Maybe()
+
+			executor := NewMockExecutor(t)
+			executor.EXPECT().executeRequests(context.Background()).Return().Maybe()
+			executor.EXPECT().registerMeterCallbacks().Return(nil).Maybe()
+
+			scheduler, err := NewConcurrentScheduler(processor, []Executor{executor}, "", interval)
+			assert.NoError(err)
+
+			if testCase.paused {
+				scheduler.Pause(context.Background())
+			}
+
+			go func() {
+				err := scheduler.Start(context.Background())
+				assert.NoError(err)
+			}()
+
+			time.Sleep(10 * time.Millisecond) // Sleep for a couple of ms to ensure that the scheduler has started.
+
+			// Act
+			err = scheduler.Start(context.Background())
+
+			// Assert
+			assert.EqualError(err, "scheduler is already started")
+		})
+	}
+}
+
+func TestConcurrentScheduler_Shutdown_not_running(t *testing.T) {
+	testCases := map[string]struct {
+		paused bool
+	}{
+		"not paused": {},
+		"paused": {
+			paused: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Arrange
+			processor := NewMockProcessor(t)
+			executor := NewMockExecutor(t)
+
+			scheduler, err := NewConcurrentScheduler(processor, []Executor{executor}, "", 100*time.Millisecond)
+			assert.NoError(err)
+
+			if testCase.paused {
+				scheduler.Pause(context.Background())
+			}
+
+			// Act
+			err = scheduler.Shutdown(context.Background())
+
+			// Assert
+			assert.EqualError(err, "scheduler is not operational")
+		})
+	}
+}
+
+func TestConcurrentScheduler_Shutdown_already_shut_down(t *testing.T) {
+	assert := assert.New(t)
+
+	// Arrange
+	interval := 100 * time.Millisecond
+
+	processor := NewMockProcessor(t)
+	processor.EXPECT().processEvents(context.Background()).Return().Maybe()
+	processor.EXPECT().registerMeterCallbacks().Return(nil).Maybe()
+	processor.EXPECT().shutdown().Return()
+	processor.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	executor := NewMockExecutor(t)
+	executor.EXPECT().executeRequests(context.Background()).Return().Maybe()
+	executor.EXPECT().registerMeterCallbacks().Return(nil).Maybe()
+	executor.EXPECT().shutdown().Return()
+	executor.EXPECT().unregisterMeterCallbacks().Return(nil)
+
+	scheduler, err := NewConcurrentScheduler(processor, []Executor{executor}, "", interval)
+	assert.NoError(err)
+
+	go func() {
+		err := scheduler.Start(context.Background())
 		assert.NoError(err)
 	}()
 

--- a/store.go
+++ b/store.go
@@ -28,13 +28,17 @@ type EventRepository interface {
 
 type HandlerRequestRepository interface {
 	CountDead(ctx context.Context) (int, error)
+	CountDeadByQueue(ctx context.Context, queueName ExecutorQueueName) (int, error)
 	CountUnexecuted(ctx context.Context) (int, error)
+	CountUnexecutedByQueue(ctx context.Context, queueName ExecutorQueueName) (int, error)
 	Create(ctx context.Context, handlerRequest *HandlerRequest) error
 	Find(ctx context.Context) iter.Seq2[*HandlerRequest, error]
 	FindByID(ctx context.Context, id string) (*HandlerRequest, error)
 	FindByIDForUpdate(ctx context.Context, id string, skipLocked bool) (*HandlerRequest, error)
 	FindDead(ctx context.Context, limit int, offset int) ([]*HandlerRequest, error)
 	FindOldestUnexecuted(ctx context.Context) (*HandlerRequest, error)
+	FindOldestUnexecutedByQueue(ctx context.Context, queueName ExecutorQueueName) (*HandlerRequest, error)
 	FindUnexecuted(ctx context.Context, limit int) ([]*HandlerRequest, error)
+	FindUnexecutedByQueue(ctx context.Context, queueName ExecutorQueueName, limit int) ([]*HandlerRequest, error)
 	Update(ctx context.Context, handlerRequest *HandlerRequest) error
 }


### PR DESCRIPTION
This PR adds a new "executor queue" concept. An executor queue represents a set of handler requests that will be executed by a queue-specific executor.

Event handlers can be assigned to a specific executor queue. If no queue is assigned to a specific handler, the default queue will be used.

This PR also adds a new "concurrent scheduler" which can be used to concurrently schedule work for the processor and the queue executor(s).

Interfaces have been added for the scheduler, processor, and executor. Signatures for constructors and for starting the scheduler have also been updated to accomodate the changes.